### PR TITLE
fix: listen to checkbox clicks

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -48,8 +48,12 @@ app.action("custom_report", async ({ ack, body, context }) => {
   await openCustomReportModal(app, body, context);
 });
 
+app.action("categories", async ({ ack}) => {
+  await ack();
+});
+
 app.view("view_custom_report", async ({ ack, body, view, context }) => {
-  await ack({ response_action: "clear" });
+  await ack();
   const url = view.state.values.custom_report_url.custom_report_input.value.trim();
   const categoryList = parseCategories(view);
   const user = body.user.id;

--- a/src/app.js
+++ b/src/app.js
@@ -48,7 +48,7 @@ app.action("custom_report", async ({ ack, body, context }) => {
   await openCustomReportModal(app, body, context);
 });
 
-app.action("categories", async ({ ack}) => {
+app.action("categories", async ({ ack }) => {
   await ack();
 });
 


### PR DESCRIPTION
Changes:
- Adds category checkbox listener to get rid of this error:
`[ERROR]  bolt-app An incoming event was not acknowledged within 3 seconds. Ensure that the ack() argument is called in a listener.`